### PR TITLE
django-model-utils不支持django-1.11，需要指定版本来兼容。

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-users2==0.2.1
 django-cors-headers==2.0.2
 djangorestframework==3.9.1
 python-jenkins==0.4.14
+django-model-utils==3.2.0
 
 # seleniumkeyword 依赖包
 selenium


### PR DESCRIPTION
https://pypi.org/project/django-model-utils/

4.0.0 (2019-12-11)
Remove hacks for previously supported Django versions. (Fixes GH-390)
Dropped support for Python 2.7. (Fixes GH-393)
Dropped usage of six
**Drop support for Django 1.11**
Add support for Python 3.8
Add support for Django 3.0