### PR TITLE
fix: 修复元素定位失败问题

### DIFF
--- a/automatic/element/models.py
+++ b/automatic/element/models.py
@@ -14,10 +14,10 @@ class Element(models.Model):
         ('name','name'),
         ('css selector','css selector'),
         ('xpath','xpath'),
-        ('class_name','class name'),
-        ('tag_name','tag name'),
-        ('link_text','link text'),
-        ('portial_link_text','portial link text')
+        ('class name','class name'),
+        ('tag name','tag name'),
+        ('link text','link text'),
+        ('portial link_text','portial link text')
     )
     projectid = models.ForeignKey(Project, editable=True, on_delete=models.DO_NOTHING)
     moduleid = models.ForeignKey(Module, editable=True, on_delete=models.DO_NOTHING)


### PR DESCRIPTION
1.class name、tag name、link text和portial link_text
值不能带下划线，详情参考https://github.com/radiateboy/automagic/issues/43#issue-922417136